### PR TITLE
Port patches from stackhpc/rocky to stable/stein

### DIFF
--- a/tests/resources/test_slackformat.template
+++ b/tests/resources/test_slackformat.template
@@ -1,0 +1,1 @@
+{{ alarm_name }} has triggered on {% for item in metrics %}host {{ metrics[0].dimensions.hostname }}, service {{ item.dimensions.service }}{% if not loop.last %}, {% endif %}{% endfor %}.


### PR DESCRIPTION
The following changes are in stable/stein:

    # https://review.opendev.org/#/c/656780/
    # https://review.opendev.org/#/c/656783/

leaving only:

    # https://review.opendev.org/#/c/519630/