### PR TITLE
Minimal fix for spawning periodic notification process

### DIFF
--- a/monasca_notification/main.py
+++ b/monasca_notification/main.py
@@ -108,7 +108,7 @@ def main(argv=None):
         args=(retry_engine.RetryEngine,))
     )
 
-    if 60 in CONF.kafka.periodic:
+    if '60' in CONF.kafka.periodic.keys():
         processors.append(multiprocessing.Process(
             target=start_process,
             args=(periodic_engine.PeriodicEngine, 60))


### PR DESCRIPTION
The current comparision between an int and a dict always returns
false so the periodic notification process never spawns. This minimal
fix should get it working again. A later patch could support user
defined periods.

Change-Id: If0649a1fe6a5337a20f0aba9a1a4ea8a0dd04617